### PR TITLE
Single Name Field

### DIFF
--- a/db/migrations/20210129201213_single_name_field.sql
+++ b/db/migrations/20210129201213_single_name_field.sql
@@ -1,15 +1,29 @@
 -- migrate:up
 -- Add new single name field
-ALTER TABLE users ADD COLUMN name VARCHAR;
-COMMENT ON COLUMN users.name IS 'Name of user, may or may not be full name.';
+ALTER TABLE users ADD COLUMN full_name VARCHAR;
+COMMENT ON COLUMN users.full_name IS 'Name of user, may or may not be full name.';
 
 -- Migrate names over
-UPDATE users SET name = users.first_name || ' ' || users.last_name;
+UPDATE users SET full_name = COALESCE(users.first_name, '') || ' ' || COALESCE(users.last_name, '');
 
-ALTER TABLE users ALTER COLUMN name SET NOT NULL;
+ALTER TABLE users ALTER COLUMN full_name SET NOT NULL;
 
 -- Drop old name fields
 ALTER TABLE users DROP COLUMN first_name CASCADE, DROP COLUMN last_name CASCADE;
 
+-- Display name is either full name or preferred name if set
+ALTER TABLE users
+  ADD COLUMN display_name VARCHAR
+    GENERATED ALWAYS AS (COALESCE(preferred_name, full_name)) STORED;
+
+COMMENT ON COLUMN users.display_name IS 'Name to use in UIs for user.';
+
 -- migrate:down
 
+ALTER TABLE users DROP COLUMN full_name CASCADE; -- Also drops display_name
+
+ALTER TABLE users
+  ADD COLUMN
+    first_name VARCHAR,
+  ADD COLUMN
+    last_name VARCHAR;

--- a/db/migrations/20210129201213_single_name_field.sql
+++ b/db/migrations/20210129201213_single_name_field.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+-- Add new single name field
+ALTER TABLE users ADD COLUMN name VARCHAR;
+COMMENT ON COLUMN users.name IS 'Name of user, may or may not be full name.';
+
+-- Migrate names over
+UPDATE users SET name = users.first_name || ' ' || users.last_name;
+
+ALTER TABLE users ALTER COLUMN name SET NOT NULL;
+
+-- Drop old name fields
+ALTER TABLE users DROP COLUMN first_name CASCADE, DROP COLUMN last_name CASCADE;
+
+-- migrate:down
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -350,115 +350,6 @@ COMMENT ON COLUMN public.enrollments.final_grade IS '0.0-100.0';
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.users (
-    username character varying NOT NULL,
-    preferred_name character varying,
-    first_name character varying NOT NULL,
-    last_name character varying NOT NULL,
-    cohort integer,
-    role public.user_role NOT NULL,
-    timezone text DEFAULT 'America/New_York'::text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: TABLE users; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.users IS 'Users can be students, external mentors, and faculty.
-Their user details are not dependent on the semester';
-
-
---
--- Name: COLUMN users.preferred_name; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.preferred_name IS 'Optional preferred first name to use in UIs';
-
-
---
--- Name: COLUMN users.first_name; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.first_name IS 'Given name of user';
-
-
---
--- Name: COLUMN users.last_name; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.last_name IS 'Family name of user';
-
-
---
--- Name: COLUMN users.cohort; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.cohort IS 'Entry year (only set for students)';
-
-
---
--- Name: COLUMN users.role; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.role IS 'Role of user in RCOS, determines permissions';
-
-
---
--- Name: COLUMN users.timezone; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.users.timezone IS 'Timezone from TZ list';
-
-
---
--- Name: coordinators; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.coordinators AS
- SELECT DISTINCT e.semester_id,
-    u.username,
-    u.preferred_name,
-    u.first_name,
-    u.last_name
-   FROM (public.users u
-     JOIN public.enrollments e ON (((e.username)::text = (u.username)::text)))
-  WHERE (e.is_coordinator = true)
-  ORDER BY e.semester_id, u.username;
-
-
---
--- Name: VIEW coordinators; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON VIEW public.coordinators IS 'View for access to Coordinators each semester';
-
-
---
--- Name: faculty_advisors; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.faculty_advisors AS
- SELECT u.username,
-    u.preferred_name,
-    u.first_name,
-    u.last_name
-   FROM public.users u
-  WHERE (u.role = 'faculty_advisor'::public.user_role);
-
-
---
--- Name: VIEW faculty_advisors; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON VIEW public.faculty_advisors IS 'View for access to Faculty Advisors';
-
-
---
 -- Name: final_grade_appeal; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1244,6 +1135,56 @@ COMMENT ON COLUMN public.user_accounts.type IS 'Type of external account that is
 --
 
 COMMENT ON COLUMN public.user_accounts.account_id IS 'Unique ID/username of account';
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    username character varying NOT NULL,
+    cohort integer,
+    role public.user_role NOT NULL,
+    timezone text DEFAULT 'America/New_York'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    name character varying NOT NULL
+);
+
+
+--
+-- Name: TABLE users; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.users IS 'Users can be students, external mentors, and faculty.
+Their user details are not dependent on the semester';
+
+
+--
+-- Name: COLUMN users.cohort; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.cohort IS 'Entry year (only set for students)';
+
+
+--
+-- Name: COLUMN users.role; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.role IS 'Role of user in RCOS, determines permissions';
+
+
+--
+-- Name: COLUMN users.timezone; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.timezone IS 'Timezone from TZ list';
+
+
+--
+-- Name: COLUMN users.name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.name IS 'Name of user, may or may not be full name.';
 
 
 --
@@ -2062,4 +2003,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20210117191050'),
     ('20210117194733'),
     ('20210122203649'),
-    ('20210122222933');
+    ('20210122222933'),
+    ('20210129201213');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1147,7 +1147,9 @@ CREATE TABLE public.users (
     role public.user_role NOT NULL,
     timezone text DEFAULT 'America/New_York'::text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    name character varying NOT NULL
+    preferred_name character varying,
+    full_name character varying NOT NULL,
+    display_name character varying GENERATED ALWAYS AS (COALESCE(preferred_name, full_name)) STORED
 );
 
 
@@ -1181,10 +1183,10 @@ COMMENT ON COLUMN public.users.timezone IS 'Timezone from TZ list';
 
 
 --
--- Name: COLUMN users.name; Type: COMMENT; Schema: public; Owner: -
+-- Name: COLUMN users.full_name; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.users.name IS 'Name of user, may or may not be full name.';
+COMMENT ON COLUMN public.users.full_name IS 'Name of user, may or may not be full name.';
 
 
 --


### PR DESCRIPTION
As discussed, it is better to have a single `name` field than separating first and last names as not everyone's name conforms to that pattern. This migration adds the new `name` column and transfers and old names over by concatenating existing first and last names. It then removes `first_name`, `last_name`, and `preferred_name`.