### PR TITLE
Constrain linked user accounts to be unique on the platform

### DIFF
--- a/migrations/1615926534831_constrain_user_accounts_unique/down.sql
+++ b/migrations/1615926534831_constrain_user_accounts_unique/down.sql
@@ -1,0 +1,2 @@
+-- Remove the created constraint
+ALTER TABLE user_accounts DROP CONSTRAINT unique_type_account_id;

--- a/migrations/1615926534831_constrain_user_accounts_unique/up.sql
+++ b/migrations/1615926534831_constrain_user_accounts_unique/up.sql
@@ -1,0 +1,6 @@
+-- Add unique constraint to user accounts so there cannot be two users linked to
+-- the same github/discord/etc.
+
+ALTER TABLE user_accounts
+ADD CONSTRAINT unique_type_account_id
+UNIQUE (type, account_id);


### PR DESCRIPTION
This prevents the same discord/github/etc from being linked to separate accounts in the RCOS database. 