### PR TITLE
Update draft flag on meetings table

### DIFF
--- a/migrations/1618351261768_alter_meetings_is_public/down.sql
+++ b/migrations/1618351261768_alter_meetings_is_public/down.sql
@@ -1,0 +1,10 @@
+-- Reverse the effects of up.sql.
+
+-- Recreate the is_public column.
+ALTER TABLE meetings ADD COLUMN is_public BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Set is_public to false on drafts.
+UPDATE meetings SET is_public = TRUE WHERE is_draft = FALSE;
+
+-- Remove the is_draft flag.
+ALTER TABLE meetings DROP COLUMN is_draft;

--- a/migrations/1618351261768_alter_meetings_is_public/down.sql
+++ b/migrations/1618351261768_alter_meetings_is_public/down.sql
@@ -8,3 +8,15 @@ UPDATE meetings SET is_public = TRUE WHERE is_draft = FALSE;
 
 -- Remove the is_draft flag.
 ALTER TABLE meetings DROP COLUMN is_draft;
+
+-- Re-create the public meetings view.
+CREATE VIEW public_meetings AS
+SELECT * FROM meetings AS m
+WHERE m.is_public = TRUE
+ORDER BY m.start_date_time;
+
+COMMENT ON VIEW public_meetings IS 'View for access to public meetings';
+
+-- Re-create original comment on is_public column.
+COMMENT ON COLUMN meetings.is_public
+IS 'True if it appears on the schedule publicly (can be used for drafts)';

--- a/migrations/1618351261768_alter_meetings_is_public/up.sql
+++ b/migrations/1618351261768_alter_meetings_is_public/up.sql
@@ -9,5 +9,9 @@ IS 'Flag to indicate this meeting is a draft, and the details are not final.';
 -- Set the value to true if the old flag was false.
 UPDATE meetings SET is_draft = TRUE WHERE is_public = FALSE;
 
+-- Drop the public_meetings view. We could update it, but it's preferable for
+-- clients to just use GraphQl filters and ordering in their queries.
+DROP VIEW public_meetings;
+
 -- Remove the old flag.
 ALTER TABLE meetings DROP COLUMN is_public;

--- a/migrations/1618351261768_alter_meetings_is_public/up.sql
+++ b/migrations/1618351261768_alter_meetings_is_public/up.sql
@@ -1,0 +1,13 @@
+-- Clarify the draft flag on the meetings table.
+
+ALTER TABLE meetings ADD COLUMN is_draft BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Indicate that this flag denotes draft status.
+COMMENT ON COLUMN meetings.is_draft
+IS 'Flag to indicate this meeting is a draft, and the details are not final.';
+
+-- Set the value to true if the old flag was false.
+UPDATE meetings SET is_draft = TRUE WHERE is_public = FALSE;
+
+-- Remove the old flag.
+ALTER TABLE meetings DROP COLUMN is_public;


### PR DESCRIPTION
This migration replaces the `is_public` column of the meetings table with an `is_draft` column for the sake of clarity. It also removes the `public_meetings` view, since the filtering and ordering can be left to hasura, and it will slightly simplify the API. 

This migration has the potential to break existing calendar and schedule frontends. It can be merged now, but should not be applied to the production database until telescope is updated to support it (telescope 0.5.0). 