### PR TITLE
Separate chat associations table

### DIFF
--- a/migrations/1622873051771_separate_chat_associations/down.sql
+++ b/migrations/1622873051771_separate_chat_associations/down.sql
@@ -1,9 +1,7 @@
 -- Undo everything in up.sql.
 
 -- Start by recreating chat association types
-
 CREATE TYPE chat_association_source AS ENUM ('project', 'small_group');
-
 COMMENT ON TYPE chat_association_source IS 'The kind of group this chat is for';
 
 CREATE TYPE chat_association_target AS ENUM (
@@ -12,7 +10,6 @@ CREATE TYPE chat_association_target AS ENUM (
     'discord_voice_channel',
     'discord_category',
     'discord_role');
-
 COMMENT ON TYPE chat_association_target IS 'The kind of chat that this refers to';
 
 -- And then recreate the chat associations table.
@@ -23,7 +20,6 @@ CREATE TABLE chat_associations (
     source_id VARCHAR NOT NULL,
     target_id VARCHAR NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-
     PRIMARY KEY (source_type, target_type, source_id)
 );
 
@@ -40,9 +36,33 @@ Discord channel ID';
 
 -- Merge all data from other tables into chat_associations.
 
--- INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
--- SELECT 'project', ''project_id,
--- FROM project_channels;
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'project', 'discord_text_channel', CAST(project_id AS VARCHAR), channel_id, created_at
+FROM project_channels WHERE kind = 'discord_text';
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'project', 'discord_voice_channel', CAST(project_id AS VARCHAR), channel_id, created_at
+FROM project_channels WHERE kind = 'discord_voice';
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'project', 'discord_role', CAST(project_id AS VARCHAR), role_id, created_at
+FROM project_roles;
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'small_group', 'discord_text_channel', CAST(small_group_id AS VARCHAR), channel_id, created_at
+FROM small_group_channels WHERE kind = 'discord_text';
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'small_group', 'discord_voice_channel', CAST(small_group_id AS VARCHAR), channel_id, created_at
+FROM small_group_channels WHERE kind = 'discord_voice';
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'small_group', 'discord_role', CAST(small_group_id AS VARCHAR), role_id, created_at
+FROM small_group_roles;
+
+INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+SELECT 'small_group', 'discord_category', CAST(small_group_id AS VARCHAR), category_id, created_at
+FROM small_group_categories;
 
 -- Drop old tables.
 DROP TABLE project_channels;
@@ -50,3 +70,6 @@ DROP TABLE project_roles;
 DROP TABLE small_group_channels;
 DROP TABLE small_group_roles;
 DROP TABLE small_group_categories;
+
+-- Drop old channel variant type.
+DROP TYPE channel_type;

--- a/migrations/1622873051771_separate_chat_associations/down.sql
+++ b/migrations/1622873051771_separate_chat_associations/down.sql
@@ -1,0 +1,52 @@
+-- Undo everything in up.sql.
+
+-- Start by recreating chat association types
+
+CREATE TYPE chat_association_source AS ENUM ('project', 'small_group');
+
+COMMENT ON TYPE chat_association_source IS 'The kind of group this chat is for';
+
+CREATE TYPE chat_association_target AS ENUM (
+    'discord_server',
+    'discord_text_channel',
+    'discord_voice_channel',
+    'discord_category',
+    'discord_role');
+
+COMMENT ON TYPE chat_association_target IS 'The kind of chat that this refers to';
+
+-- And then recreate the chat associations table.
+-- This code is just from the original chat associations migration.
+CREATE TABLE chat_associations (
+    source_type chat_association_source NOT NULL,
+    target_type chat_association_target NOT NULL,
+    source_id VARCHAR NOT NULL,
+    target_id VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (source_type, target_type, source_id)
+);
+
+COMMENT ON TABLE chat_associations IS 'Association of chat platform channel or
+other entity with a small group or project';
+COMMENT ON COLUMN chat_associations.source_type IS 'What the target is
+associated with, e.g. project or small group';
+COMMENT ON COLUMN chat_associations.target_type IS 'What the source is
+associated with, e.g. Discord TEXT channel';
+COMMENT ON COLUMN chat_associations.source_id IS 'ID of source, e.g. project id
+or small group id';
+COMMENT ON COLUMN chat_associations.target_id IS 'ID of target on platform, e.g.
+Discord channel ID';
+
+-- Merge all data from other tables into chat_associations.
+
+-- INSERT INTO chat_associations(source_type, target_type, source_id, target_id, created_at)
+-- SELECT 'project', ''project_id,
+-- FROM project_channels;
+
+-- Drop old tables.
+DROP TABLE project_channels;
+DROP TABLE project_roles;
+DROP TABLE small_group_channels;
+DROP TABLE small_group_roles;
+DROP TABLE small_group_categories;

--- a/migrations/1622873051771_separate_chat_associations/up.sql
+++ b/migrations/1622873051771_separate_chat_associations/up.sql
@@ -1,0 +1,23 @@
+-- This migration separates the chat associations table out into separate tables
+-- based on source type.
+
+CREATE TABLE project_channels (
+    -- The project that this chat association is for.
+    project_id INTEGER NOT NULL REFERENCES projects(project_id),
+
+    -- The ID of this Discord channel.
+    channel_id VARCHAR NOT NULL UNIQUE,
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (project_id, channel_id)
+);
+
+COMMENT ON TABLE project_channels IS 'The Discord channel IDs associated with projects.';
+COMMENT ON COLUMN project_channels.project_id IS 'The RCOS project ID.';
+COMMENT ON COLUMN project_channels.channel_id IS 'The Discord channel ID for this project''s channel. This can be a text channel or voice channel. We do not store which. Clients should query the discord API for this information.';
+
+-- Add all the project channels to the new table.
+INSERT INTO project_channels(project_id, channel_id, created_at)
+SELECT source_id, target_id, created_at FROM chat_associations
+WHERE target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel';

--- a/migrations/1622873051771_separate_chat_associations/up.sql
+++ b/migrations/1622873051771_separate_chat_associations/up.sql
@@ -1,6 +1,10 @@
 -- This migration separates the chat associations table out into separate tables
 -- based on source type.
 
+-- We use inner joins through out this file rather than just checking the
+-- chat associations source type because the inner join will guarantee
+-- that we don't violate a foreign key constraint.
+
 CREATE TABLE project_channels (
     -- The project that this chat association is for.
     project_id INTEGER NOT NULL REFERENCES projects(project_id),
@@ -13,12 +17,66 @@ CREATE TABLE project_channels (
 
 COMMENT ON TABLE project_channels IS 'The Discord channel IDs associated with projects.';
 COMMENT ON COLUMN project_channels.project_id IS 'The RCOS project ID.';
-COMMENT ON COLUMN project_channels.channel_id IS 'The Discord channel ID for this project''s channel. This can be a text channel or voice channel. We do not store which. Clients should query the discord API for this information.';
+COMMENT ON COLUMN project_channels.channel_id IS 'The Discord channel ID.';
 
 -- Add all the project channels to the new table.
 INSERT INTO project_channels(project_id, channel_id, created_at)
 SELECT projects.project_id, chat_associations.target_id, chat_associations.created_at
 FROM projects INNER JOIN chat_associations ON projects.project_id = chat_associations.source_id
-WHERE (target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel');
+WHERE (target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel')
+  AND source_type = 'project';
 
+-- Next do the same for small group channels
+CREATE TABLE small_group_channels (
+    -- Associated small group
+    small_group_id INTEGER NOT NULL REFERENCES small_groups(small_group_id),
+
+    -- The ID of the discord channel
+    channel_id VARCHAR PRIMARY KEY,
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE small_group_channels IS 'The Discord channel IDs associated with small groups.';
+COMMENT ON COLUMN small_group_channels.small_group_id IS 'The ID of the small group.';
+COMMENT ON COLUMN small_group_channels.channel_id IS 'The Discord channel ID.';
+
+INSERT INTO small_group_channels(small_group_id, channel_id, created_at)
+SELECT small_group_id, target_id, chat_associations.created_at
+FROM small_groups INNER JOIN chat_associations ON small_group_id = source_id
+WHERE (target_type = 'discord_voice_channel' OR target_type = 'discord_text_channel')
+  AND source_type = 'small_group';
+
+-- Do the same for both for roles.
+-- Projects first.
+CREATE TABLE project_roles (
+    project_id INTEGER NOT NULL REFERENCES projects(project_id),
+    role_id VARCHAR PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE project_roles IS 'Discord roles associated with projects.';
+COMMENT ON COLUMN project_roles.project_id IS 'The project ID.';
+COMMENT ON COLUMN project_roles.role_id IS 'The Discord role ID.';
+
+INSERT INTO project_roles(project_id, role_id, created_at)
+SELECT project_id, target_id, chat_associations.created_at
+FROM projects INNER JOIN chat_associations ON project_id = source_id
+WHERE target_type = 'discord_role' AND source_type = 'project';
+
+-- Then small groups
+CREATE TABLE small_group_roles (
+    small_group_id INTEGER NOT NULL REFERENCES small_groups(small_group_id),
+    role_id VARCHAR PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE small_group_roles IS 'The Discord roles associated with small groups.';
+COMMENT ON COLUMN small_group_roles.small_group_id IS 'The associated small group ID.';
+COMMENT ON COLUMN small_group_roles.role_id IS 'The Discord role ID.';
+
+INSERT INTO small_group_roles(small_group_id, role_id, created_at)
+SELECT small_group_id, target_id, chat_associations.created_at
+FROM small_groups INNER JOIN chat_associations ON small_group_id = source_id
+WHERE source_type = 'small_group' AND target_type = 'discord_role';
 

--- a/migrations/1622873051771_separate_chat_associations/up.sql
+++ b/migrations/1622873051771_separate_chat_associations/up.sql
@@ -6,11 +6,9 @@ CREATE TABLE project_channels (
     project_id INTEGER NOT NULL REFERENCES projects(project_id),
 
     -- The ID of this Discord channel.
-    channel_id VARCHAR NOT NULL UNIQUE,
+    channel_id VARCHAR PRIMARY KEY,
 
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-
-    PRIMARY KEY (project_id, channel_id)
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 
 COMMENT ON TABLE project_channels IS 'The Discord channel IDs associated with projects.';
@@ -19,5 +17,8 @@ COMMENT ON COLUMN project_channels.channel_id IS 'The Discord channel ID for thi
 
 -- Add all the project channels to the new table.
 INSERT INTO project_channels(project_id, channel_id, created_at)
-SELECT source_id, target_id, created_at FROM chat_associations
-WHERE target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel';
+SELECT projects.project_id, chat_associations.target_id, chat_associations.created_at
+FROM projects INNER JOIN chat_associations ON projects.project_id = chat_associations.source_id
+WHERE (target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel');
+
+

--- a/migrations/1622873051771_separate_chat_associations/up.sql
+++ b/migrations/1622873051771_separate_chat_associations/up.sql
@@ -1,8 +1,13 @@
 -- This migration separates the chat associations table out into separate tables
 -- based on source type.
 
+-- Create enum to indicate the difference between discord voice and text
+-- channels.
+CREATE TYPE channel_type AS ENUM ('discord_voice', 'discord_text');
+COMMENT ON TYPE channel_type IS 'What kind of Discord channel';
+
 -- We use inner joins through out this file rather than just checking the
--- chat associations source type because the inner join will guarantee
+-- chat associations source type because the inner join will better guarantee
 -- that we don't violate a foreign key constraint.
 
 CREATE TABLE project_channels (
@@ -10,9 +15,14 @@ CREATE TABLE project_channels (
     project_id INTEGER NOT NULL REFERENCES projects(project_id),
 
     -- The ID of this Discord channel.
-    channel_id VARCHAR PRIMARY KEY,
+    channel_id VARCHAR NOT NULL UNIQUE,
 
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    -- The type of channel
+    kind channel_type NOT NULL,
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (project_id, kind)
 );
 
 COMMENT ON TABLE project_channels IS 'The Discord channel IDs associated with projects.';
@@ -20,39 +30,51 @@ COMMENT ON COLUMN project_channels.project_id IS 'The RCOS project ID.';
 COMMENT ON COLUMN project_channels.channel_id IS 'The Discord channel ID.';
 
 -- Add all the project channels to the new table.
-INSERT INTO project_channels(project_id, channel_id, created_at)
-SELECT projects.project_id, chat_associations.target_id, chat_associations.created_at
-FROM projects INNER JOIN chat_associations ON projects.project_id = chat_associations.source_id
-WHERE (target_type = 'discord_text_channel' OR target_type = 'discord_voice_channel')
-  AND source_type = 'project';
+-- First text channels
+INSERT INTO project_channels(project_id, channel_id, kind, created_at)
+SELECT project_id, target_id, 'discord_text', chat_associations.created_at
+FROM projects INNER JOIN chat_associations ON source_id = CAST(project_id AS VARCHAR)
+WHERE target_type = 'discord_text_channel' AND source_type = 'project';
+
+-- Then voice channels
+INSERT INTO project_channels(project_id, channel_id, kind, created_at)
+SELECT project_id, target_id, 'discord_voice', chat_associations.created_at
+FROM projects INNER JOIN chat_associations ON source_id = CAST(project_id AS VARCHAR)
+WHERE target_type = 'discord_voice_channel' AND source_type = 'project';
 
 -- Next do the same for small group channels
 CREATE TABLE small_group_channels (
-    -- Associated small group
     small_group_id INTEGER NOT NULL REFERENCES small_groups(small_group_id),
-
-    -- The ID of the discord channel
-    channel_id VARCHAR PRIMARY KEY,
-
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    channel_id VARCHAR UNIQUE NOT NULL,
+    kind channel_type NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (small_group_id, kind)
 );
 
 COMMENT ON TABLE small_group_channels IS 'The Discord channel IDs associated with small groups.';
 COMMENT ON COLUMN small_group_channels.small_group_id IS 'The ID of the small group.';
 COMMENT ON COLUMN small_group_channels.channel_id IS 'The Discord channel ID.';
 
-INSERT INTO small_group_channels(small_group_id, channel_id, created_at)
-SELECT small_group_id, target_id, chat_associations.created_at
-FROM small_groups INNER JOIN chat_associations ON small_group_id = source_id
-WHERE (target_type = 'discord_voice_channel' OR target_type = 'discord_text_channel')
-  AND source_type = 'small_group';
+INSERT INTO small_group_channels(small_group_id, channel_id, kind, created_at)
+SELECT small_group_id, target_id, 'discord_voice', chat_associations.created_at
+FROM small_groups INNER JOIN chat_associations ON source_id = CAST(small_group_id AS VARCHAR)
+WHERE target_type = 'discord_voice_channel' AND source_type = 'small_group';
 
--- Do the same for both for roles.
+INSERT INTO small_group_channels(small_group_id, channel_id, kind, created_at)
+SELECT small_group_id, target_id, 'discord_text', chat_associations.created_at
+FROM small_groups INNER JOIN chat_associations ON source_id = CAST(small_group_id AS VARCHAR)
+WHERE target_type = 'discord_text_channel' AND source_type = 'small_group';
+
+-- Do similar for both for roles.
+-- Only difference is that there cannot be multiple roles for a project
+-- or small group, so no variant flag.
+
 -- Projects first.
 CREATE TABLE project_roles (
-    project_id INTEGER NOT NULL REFERENCES projects(project_id),
-    role_id VARCHAR PRIMARY KEY,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    project_id INTEGER UNIQUE NOT NULL REFERENCES projects(project_id),
+    role_id VARCHAR UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (project_id, role_id)
 );
 
 COMMENT ON TABLE project_roles IS 'Discord roles associated with projects.';
@@ -61,14 +83,15 @@ COMMENT ON COLUMN project_roles.role_id IS 'The Discord role ID.';
 
 INSERT INTO project_roles(project_id, role_id, created_at)
 SELECT project_id, target_id, chat_associations.created_at
-FROM projects INNER JOIN chat_associations ON project_id = source_id
+FROM projects INNER JOIN chat_associations ON source_id = CAST(project_id AS VARCHAR)
 WHERE target_type = 'discord_role' AND source_type = 'project';
 
 -- Then small groups
 CREATE TABLE small_group_roles (
-    small_group_id INTEGER NOT NULL REFERENCES small_groups(small_group_id),
-    role_id VARCHAR PRIMARY KEY,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+    small_group_id INTEGER UNIQUE NOT NULL REFERENCES small_groups(small_group_id),
+    role_id VARCHAR UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (small_group_id, role_id)
 );
 
 COMMENT ON TABLE small_group_roles IS 'The Discord roles associated with small groups.';
@@ -77,6 +100,32 @@ COMMENT ON COLUMN small_group_roles.role_id IS 'The Discord role ID.';
 
 INSERT INTO small_group_roles(small_group_id, role_id, created_at)
 SELECT small_group_id, target_id, chat_associations.created_at
-FROM small_groups INNER JOIN chat_associations ON small_group_id = source_id
+FROM small_groups INNER JOIN chat_associations ON source_id = CAST(small_group_id AS VARCHAR)
 WHERE source_type = 'small_group' AND target_type = 'discord_role';
 
+-- Create table for small group categories. We allow multiple categories per
+-- small group for now.
+CREATE TABLE small_group_categories (
+    small_group_id INTEGER NOT NULL REFERENCES small_groups(small_group_id),
+    category_id VARCHAR PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE small_group_categories
+    IS 'The Discord category IDs associated with small groups.';
+COMMENT ON COLUMN small_group_categories.small_group_id IS 'The small group ID.';
+COMMENT ON COLUMN small_group_categories.category_id IS 'The Discord category ID.';
+
+INSERT INTO small_group_categories(small_group_id, category_id, created_at)
+SELECT small_group_id, target_id, chat_associations.created_at
+FROM small_groups INNER JOIN chat_associations ON source_id = CAST(small_group_id AS VARCHAR)
+WHERE source_type = 'small_group' AND target_type = 'discord_category';
+
+-- We do not preserve records of Discord servers. There should not be external
+-- Discord servers for small groups, and projects using external Discord servers
+-- should publicize them in their Discord channels.
+
+-- Drop the old chat associations table and the types associated.
+DROP TABLE chat_associations;
+DROP TYPE chat_association_source;
+DROP TYPE chat_association_target;


### PR DESCRIPTION
This migration separates the chat associations table for more minute control of chat associations with fewer enum types. This may break existing clients/discord bots. 

Closes #29 