### PR TITLE
Replace meeting agrendas with meeting decriptions

### DIFF
--- a/migrations/1623899398293_alter_meeetings_agenda/down.sql
+++ b/migrations/1623899398293_alter_meeetings_agenda/down.sql
@@ -1,0 +1,8 @@
+-- Undo up.sql.
+
+-- Add back the agenda column.
+ALTER TABLE meetings ADD COLUMN agenda VARCHAR[] DEFAULT '{}'::VARCHAR[];
+COMMENT ON COLUMN meetings.agenda IS 'List of agenda items that will be covered in the meeting';
+
+-- Drop description column.
+ALTER TABLE meetings DROP COLUMN description;

--- a/migrations/1623899398293_alter_meeetings_agenda/up.sql
+++ b/migrations/1623899398293_alter_meeetings_agenda/up.sql
@@ -1,0 +1,15 @@
+-- This migration replaces the agenda column of the meetings table
+-- with a more general purpose description column.
+
+-- Add description column.
+ALTER TABLE meetings ADD COLUMN description TEXT NOT NULL DEFAULT '';
+COMMENT ON COLUMN meetings.description IS 'Description of the meeting in CommonMark markdown or plaintext.';
+
+-- Convert all agendas to descriptions. This is the word agenda, followed by
+-- a bulleted list of the agenda items on newlines.
+UPDATE meetings
+SET description = E'Agenda:\n' || array_to_string(agenda, E'\n- ')
+WHERE array_length(agenda, 1) > 1;
+
+-- Drop the agenda column.
+ALTER TABLE meetings DROP COLUMN agenda;


### PR DESCRIPTION
Descriptions are more versatile than agenda lists. This PR replaces meeting agendas with markdown descriptions. This also eliminates a use of arrays, which is a step in the right direction for usability (see #28). 