### PR TITLE
Add updated_at to projects and update hasura

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         - "443:443"
 
     hasura:
-        image: hasura/graphql-engine:v2.2.0
+        image: hasura/graphql-engine:v2.4.0
         restart: unless-stopped
         environment:
             # https://hasura.io/docs/1.0/graphql/core/deployment/graphql-engine-flags/reference.html

--- a/migrations/1649450066130_alter_table_public_projects_add_column_updated_at/down.sql
+++ b/migrations/1649450066130_alter_table_public_projects_add_column_updated_at/down.sql
@@ -1,0 +1,6 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."projects" add column "updated_at" timestamptz
+--  null;
+
+ALTER table "public"."projects" DROP COLUMN IF EXISTS updated_at;

--- a/migrations/1649450066130_alter_table_public_projects_add_column_updated_at/up.sql
+++ b/migrations/1649450066130_alter_table_public_projects_add_column_updated_at/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."projects" add column "updated_at" timestamptz
+ default now();

--- a/migrations/1649450545541_create_projects_update_trigger/down.sql
+++ b/migrations/1649450545541_create_projects_update_trigger/down.sql
@@ -1,0 +1,16 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE FUNCTION update_modified_now() RETURNS trigger AS $update_modified_now$
+-- BEGIN
+--     IF NEW.update_at IS NULL THEN
+--         NEW.update_at := current_timestamp;
+--     END IF;
+--     return NEW;
+-- END;
+-- $update_modified_now$ LANGUAGE plpgsql;
+--
+-- CREATE TRIGGER project_update_modified BEFORE INSERT OR UPDATE on projects
+--     FOR EACH ROW EXECUTE FUNCTION update_modified_now();
+
+DROP TRIGGER IF EXISTS project_update_modified on projects;
+DROP FUNCTION IF EXISTS update_modified_now();

--- a/migrations/1649450545541_create_projects_update_trigger/up.sql
+++ b/migrations/1649450545541_create_projects_update_trigger/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION update_modified_now() RETURNS trigger AS $update_modified_now$
+BEGIN
+    IF NEW.updated_at = OLD.updated_at THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    return NEW;
+END;
+$update_modified_now$ LANGUAGE plpgsql;
+
+CREATE TRIGGER project_update_modified BEFORE UPDATE on projects
+    FOR EACH ROW EXECUTE FUNCTION update_modified_now();


### PR DESCRIPTION
I'm adding this field to import data from Observatory without losing it and also to display when a project was last updated.
I tested to make sure this does not break functionality and there are no breaking changes.
When this is merged I will also create a pull request to sync the changes to Telescope.